### PR TITLE
Add missing prototype to smtc_hal_gpio.h

### DIFF
--- a/smtc_hal/inc/smtc_hal_gpio.h
+++ b/smtc_hal/inc/smtc_hal_gpio.h
@@ -49,6 +49,8 @@ extern "C" {
 
 void hal_gpio_init( void );
 
+void hal_gpio_deinit( uint32_t pin );
+
 void hal_gpio_task_init( void );
 
 void hal_gpio_init_in( uint32_t pin, const hal_gpio_pull_mode_t pull_mode, const hal_gpio_irq_mode_t irq_mode, hal_gpio_irq_t* irq );


### PR DESCRIPTION
This method is used in https://github.com/Seeed-Studio/Seeed_Wio_WM1110_Dev_Board/blob/fa912a0cfcc0abadfdd0fb53e1fce36fe954f733/wm1110/LR11XX/smtc_shield_lr11xx/common/src/smtc_shield_lr11x0_common.c#L139, but is missing a prototype, which is a hard error by default in C23.